### PR TITLE
Fix boolean conversions (jankson -> x)

### DIFF
--- a/src/main/java/io/github/cottonmc/jankson/JanksonOps.java
+++ b/src/main/java/io/github/cottonmc/jankson/JanksonOps.java
@@ -64,6 +64,8 @@ public class JanksonOps implements DynamicOps<JsonElement> {
             Object value = ((JsonPrimitive) input).getValue();
             if (value instanceof Number) {
                 return Optional.of((Number) value);
+            } else if (value instanceof Boolean) {
+                return Optional.of((Boolean) value ? 1 : 0);
             }
         }
         return Optional.empty();


### PR DESCRIPTION
Currently, when Jankson boolean primitives are converted using DFU, they become false. DFU expects booleans to be encoded as NBT-like numbers in `getNumberValue`, but JanksonOps (and Mojang's own JsonOps) is missing the number conversion for booleans.

This PR adds that conversion, so you can use JanksonOps to convert from Jankson to Gson properly.