### PR TITLE
Update JanksonOps to work on latest dfu version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-	id 'fabric-loom' version '0.2.5-SNAPSHOT'
+	id 'fabric-loom' version '0.5-SNAPSHOT'
 	id 'maven-publish'
 	id "com.jfrog.artifactory" version "4.9.0"
 }
@@ -33,7 +33,7 @@ minecraft {
 
 dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=19w38b
-	yarn_mappings=19w38b+build.4
-	loader_version=0.6.2+build.166
+	minecraft_version=1.16.4
+	yarn_mappings=1.16.4+build.7
+	loader_version=0.10.8
 
 # Mod Properties
 	mod_version = 2.0.1+j1.2.0

--- a/src/main/java/io/github/cottonmc/jankson/BlockAndItemSerializers.java
+++ b/src/main/java/io/github/cottonmc/jankson/BlockAndItemSerializers.java
@@ -1,51 +1,29 @@
 package io.github.cottonmc.jankson;
 
-import java.util.Collection;
 import java.util.Optional;
 
 import blue.endless.jankson.JsonElement;
 import blue.endless.jankson.JsonObject;
 import blue.endless.jankson.JsonPrimitive;
 import blue.endless.jankson.api.Marshaller;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.state.property.Property;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
-import net.minecraft.world.biome.Biome;
 
 public class BlockAndItemSerializers {
-
 	public static ItemStack getItemStack(JsonObject json, Marshaller m) {
-		String itemIdString = json.get(String.class, "item");
-		Item item = (Item)Registry.ITEM.getOrEmpty(new Identifier(itemIdString)).orElse(Items.AIR);
-		ItemStack stack = new ItemStack(item);
-		if (json.containsKey("count")) {
-			Integer count = json.get(Integer.class, "count");
-			if (count!=null) {
-				stack.setCount(count);
-			}
-		}
-		return stack;
+		return ItemStack.CODEC.parse(JanksonOps.INSTANCE, json).getOrThrow(false, System.err::println);
 	}
 
 	public static ItemStack getItemStackPrimitive(String s, Marshaller m) {
-		Item item = (Item)Registry.ITEM.getOrEmpty(new Identifier(s)).orElse(Items.AIR);
-		ItemStack stack = new ItemStack(item);
-		return stack;
+		return new ItemStack(Registry.ITEM.get(new Identifier(s)));
 	}
 
 	public static JsonElement saveItemStack(ItemStack stack, Marshaller m) {
-		JsonPrimitive id = new JsonPrimitive(Registry.ITEM.getId(stack.getItem()).toString());
-		if (stack.getCount()==1) return id;
-	
-		JsonObject result = new JsonObject();
-		result.put("item", new JsonPrimitive(Registry.ITEM.getId(stack.getItem()).toString()));
-		result.put("count", new JsonPrimitive(stack.getCount()));
-		return result;
+		return ItemStack.CODEC.encode(stack, JanksonOps.INSTANCE, JanksonOps.INSTANCE.empty()).getOrThrow(false, System.err::println);
 	}
 	
 	public static Block getBlockPrimitive(String blockIdString, Marshaller m) {
@@ -56,15 +34,9 @@ public class BlockAndItemSerializers {
 	public static JsonElement saveBlock(Block block, Marshaller m) {
 		return new JsonPrimitive(Registry.BLOCK.getId(block).toString());
 	}
-	
-	
+
 	public static BlockState getBlockStatePrimitive(String blockIdString, Marshaller m) {
-		Optional<Block> blockOpt = Registry.BLOCK.getOrEmpty(new Identifier(blockIdString));
-		if (blockOpt.isPresent()) {
-			return blockOpt.get().getDefaultState();
-		} else {
-			return null;
-		}
+		return Registry.BLOCK.getOrEmpty(new Identifier(blockIdString)).map(Block::getDefaultState).orElse(null);
 	}
 	
 	/**
@@ -72,76 +44,10 @@ public class BlockAndItemSerializers {
 	 * @return the BlockState represented, or null if the object does not represent a valid BlockState.
 	 */
 	public static BlockState getBlockState(JsonObject json, Marshaller m) {
-		String blockIdString = json.get(String.class, "block");
-		
-		Block block = Registry.BLOCK.getOrEmpty(new Identifier(blockIdString)).orElse(null);
-		if (block==null) return null;
-		
-		BlockState state = block.getDefaultState();
-		JsonObject stateObject = json.getObject("BlockStateTag");
-		if (stateObject==null) stateObject = json;
-		
-		Collection<Property<?>> properties = state.getProperties();
-		for(String key : stateObject.keySet()) {
-			if (stateObject==json && (key.equals("BlockStateTag") || key.equals("block"))) continue;
-			
-			for(Property<?> property : properties) {
-				if (property.getName().equals(key)) {
-					String val = stateObject.get(String.class, key);
-					state = withProperty(state, property, val);
-					break;
-				}
-			}
-		}
-		
-		return state;
+		return BlockState.CODEC.parse(JanksonOps.INSTANCE, json).getOrThrow(false, System.err::println);
 	}
 	
 	public static JsonElement saveBlockState(BlockState state, Marshaller m) {
-		BlockState defaultState = state.getBlock().getDefaultState();
-		
-		if (state.equals(defaultState)) {
-			//Use a String for the blockID only
-			return new JsonPrimitive( Registry.BLOCK.getId(state.getBlock()).toString() );
-			
-		} else {
-			JsonObject result = new JsonObject();
-			result.put("block", new JsonPrimitive( Registry.BLOCK.getId(state.getBlock()).toString() ));
-			JsonObject stateObject = result;
-			for(Property<?> property : state.getProperties()) {
-				String key = property.getName();
-				if (key.equals("block") || key.equals("BlockStateTag")) { //Certain dangerous keys mean we should partition off blockstate properties
-					stateObject = new JsonObject();
-					result.put("BlockStateTag", stateObject);
-					break;
-				}
-			}
-			
-			for(Property<?> property : state.getProperties()) {
-				if (state.get(property).equals(defaultState.get(property))) continue;
-				String key = property.getName();
-				String val = getProperty(state, property);
-				stateObject.put(key, new JsonPrimitive(val));
-			}
-			
-			return result;
-		}
-	}
-	
-	public static <T extends Comparable<T>> BlockState withProperty(BlockState state, Property<T> property, String stringValue) {
-		Optional<T> val = property.getValue(stringValue);
-		if (val.isPresent()) {
-			return state.with(property, val.get());
-		} else {
-			return state;
-		}
-	}
-	
-	public static <T extends Comparable<T>> String getProperty(BlockState state, Property<T> property) {
-		return property.getName(state.get(property));
-	}
-	
-	public static Biome getBiome(String s, Marshaller m) {
-		return Registry.BIOME.get(new Identifier(s));
+		return BlockState.CODEC.encode(state, JanksonOps.INSTANCE, JanksonOps.INSTANCE.empty()).getOrThrow(false, System.err::println);
 	}
 }

--- a/src/main/java/io/github/cottonmc/jankson/JanksonFactory.java
+++ b/src/main/java/io/github/cottonmc/jankson/JanksonFactory.java
@@ -5,10 +5,10 @@ import blue.endless.jankson.JsonElement;
 import blue.endless.jankson.JsonNull;
 import blue.endless.jankson.JsonObject;
 import blue.endless.jankson.JsonPrimitive;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntityType;
-import net.minecraft.container.ContainerType;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ai.brain.Activity;
@@ -24,27 +24,24 @@ import net.minecraft.particle.ParticleType;
 import net.minecraft.potion.Potion;
 import net.minecraft.recipe.RecipeSerializer;
 import net.minecraft.recipe.RecipeType;
+import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.stat.StatType;
 import net.minecraft.structure.StructurePieceType;
 import net.minecraft.structure.pool.StructurePoolElementType;
 import net.minecraft.structure.processor.StructureProcessorType;
-import net.minecraft.structure.rule.RuleTest;
+import net.minecraft.structure.rule.RuleTestType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
-import net.minecraft.village.PointOfInterestType;
 import net.minecraft.village.VillagerProfession;
 import net.minecraft.village.VillagerType;
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.source.BiomeSourceType;
 import net.minecraft.world.chunk.ChunkStatus;
-import net.minecraft.world.dimension.DimensionType;
 import net.minecraft.world.gen.carver.Carver;
-import net.minecraft.world.gen.chunk.ChunkGeneratorType;
 import net.minecraft.world.gen.decorator.Decorator;
 import net.minecraft.world.gen.feature.Feature;
 import net.minecraft.world.gen.feature.StructureFeature;
 import net.minecraft.world.gen.surfacebuilder.SurfaceBuilder;
+import net.minecraft.world.poi.PointOfInterestType;
 
 public class JanksonFactory {
 	public static Jankson.Builder builder() {
@@ -71,15 +68,11 @@ public class JanksonFactory {
 		
 		//All the things you could potentially specify with just a registry ID
 		register(builder, Activity.class,           Registry.ACTIVITY);
-		register(builder, Biome.class,              Registry.BIOME);
-		register(builder, BiomeSourceType.class,    Registry.BIOME_SOURCE_TYPE);
-		register(builder, BlockEntityType.class,    Registry.BLOCK_ENTITY);
+		register(builder, BlockEntityType.class,    Registry.BLOCK_ENTITY_TYPE);
 		register(builder, Carver.class,             Registry.CARVER);
-		register(builder, ChunkGeneratorType.class, Registry.CHUNK_GENERATOR_TYPE);
 		register(builder, ChunkStatus.class,        Registry.CHUNK_STATUS);
-		register(builder, ContainerType.class,      Registry.CONTAINER);
+		register(builder, ScreenHandlerType.class,  Registry.SCREEN_HANDLER);
 		register(builder, Decorator.class,          Registry.DECORATOR);
-		register(builder, DimensionType.class,      Registry.DIMENSION);
 		
 		builder
 		//	.registerDeserializer(String.class, Activity.class,           (s,m)->Registry.ACTIVITY              .get(new Identifier(s)))
@@ -98,14 +91,14 @@ public class JanksonFactory {
 			.registerDeserializer(String.class, Fluid.class,              (s,m)->Registry.FLUID                 .get(new Identifier(s)))
 			.registerDeserializer(String.class, Item.class,               (s,m)->Registry.ITEM                  .get(new Identifier(s))) //TODO: Support tags?
 			.registerDeserializer(String.class, MemoryModuleType.class,   (s,m)->Registry.MEMORY_MODULE_TYPE    .get(new Identifier(s)))
-			.registerDeserializer(String.class, PaintingMotive.class,     (s,m)->Registry.MOTIVE                .get(new Identifier(s))) //MOTIF. It's spelled "MOTIF".
+			.registerDeserializer(String.class, PaintingMotive.class,     (s,m)->Registry.PAINTING_MOTIVE        .get(new Identifier(s))) //MOTIF. It's spelled "MOTIF".
 			.registerDeserializer(String.class, ParticleType.class,       (s,m)->Registry.PARTICLE_TYPE         .get(new Identifier(s)))
-			.registerDeserializer(String.class, PointOfInterestType.class,(s,m)->Registry.POINT_OF_INTEREST_TYPE.get(new Identifier(s)))
+			.registerDeserializer(String.class, PointOfInterestType.class,(s, m)->Registry.POINT_OF_INTEREST_TYPE.get(new Identifier(s)))
 			.registerDeserializer(String.class, Potion.class,             (s,m)->Registry.POTION                .get(new Identifier(s)))
 			.registerDeserializer(String.class, RecipeSerializer.class,   (s,m)->Registry.RECIPE_SERIALIZER     .get(new Identifier(s)))
 			.registerDeserializer(String.class, RecipeType.class,         (s,m)->Registry.RECIPE_TYPE           .get(new Identifier(s)))
 			.registerDeserializer(String.class, Registry.class,           (s,m)->Registry.REGISTRIES            .get(new Identifier(s))) //You know you want to do it
-			.registerDeserializer(String.class, RuleTest.class,           (s,m)->Registry.RULE_TEST             .get(new Identifier(s)))
+			.registerDeserializer(String.class, RuleTestType.class,       (s, m)->Registry.RULE_TEST            .get(new Identifier(s)))
 			.registerDeserializer(String.class, Schedule.class,           (s,m)->Registry.SCHEDULE              .get(new Identifier(s)))
 			.registerDeserializer(String.class, SensorType.class,         (s,m)->Registry.SENSOR_TYPE           .get(new Identifier(s)))
 			.registerDeserializer(String.class, SoundEvent.class,         (s,m)->Registry.SOUND_EVENT           .get(new Identifier(s)))


### PR DESCRIPTION
DynamicOps no longer uses Optionals for wrapping values and instead uses DataResults. This pr updates JanksonOps to work on the newer dfu versions, and updates registry serializers. Some registries, such as the ones for `ChunkGeneratorType` and `BiomeSourceType` have been replaced with a registry that stores codecs (`Codec<ChunkGenerator>` and `Codec<BiomeSource>`) so I didn't keep those.

JanksonOps code taken from [this gist](https://gist.github.com/BoogieMonster1O1/73bb870acfc3df6ce702594203b06f8e)